### PR TITLE
Implement gradient calculation test with CNN

### DIFF
--- a/neural_networks/conv.hpp
+++ b/neural_networks/conv.hpp
@@ -69,3 +69,10 @@ void ConvMatrixMultiplication(
     const std::vector<double>& biases, const int padding, const int stride,
     std::vector<Eigen::MatrixXd>* output_volume,
     std::vector<Eigen::MatrixXd>* input_channels_unrolled_return);
+
+/**
+ * TODO: Documentation.
+ */
+std::vector<Eigen::MatrixXd> ConvGradient(
+    const ConvKernels& conv_kernels,
+    const std::vector<Eigen::MatrixXd>& next_grad);

--- a/neural_networks/conv.hpp
+++ b/neural_networks/conv.hpp
@@ -76,3 +76,7 @@ void ConvMatrixMultiplication(
 std::vector<Eigen::MatrixXd> ConvGradient(
     const ConvKernels& conv_kernels,
     const std::vector<Eigen::MatrixXd>& next_grad);
+
+std::vector<Eigen::MatrixXd> ConvWeightGradient(
+    const std::vector<Eigen::MatrixXd>& input_volume,
+    const std::vector<Eigen::MatrixXd>& next_grad);

--- a/neural_networks/conv_structs.cpp
+++ b/neural_networks/conv_structs.cpp
@@ -54,6 +54,11 @@ InputOutputVolume::InputOutputVolume(const std::vector<double>& values,
   }
 }
 
+Eigen::VectorXd InputOutputVolume::GetVolumeVec() const {
+  const std::vector<double> values = GetValues();  // TODO: Avoid this copy.
+  return Eigen::Map<const Eigen::VectorXd>(values.data(), values.size());
+}
+
 std::vector<double> InputOutputVolume::GetValues() const {
   std::vector<double> values;
   for (const Eigen::MatrixXd& channel : volume_) {

--- a/neural_networks/conv_structs.cpp
+++ b/neural_networks/conv_structs.cpp
@@ -88,3 +88,20 @@ InputOutputVolume GetRandomInputOutputVolume(const std::size_t num_channels,
                 [&dist, &generator]() { return dist(generator); });
   return InputOutputVolume(values, num_channels, num_rows, num_cols);
 }
+
+InputOutputVolume operator*(const InputOutputVolume& volume_1,
+                            const InputOutputVolume& volume_2) {
+  assert(volume_1.GetNumChannels() == volume_2.GetNumChannels());
+  assert(volume_1.GetNumRows() == volume_2.GetNumRows());
+  assert(volume_1.GetNumCols() == volume_2.GetNumCols());
+
+  const std::vector<Eigen::MatrixXd>& v1 = volume_1.GetVolume();
+  const std::vector<Eigen::MatrixXd>& v2 = volume_2.GetVolume();
+
+  std::vector<Eigen::MatrixXd> v_result(v1.size());
+  for (std::size_t i = 0; i < v1.size(); ++i) {
+    v_result.at(i) = v1.at(i).cwiseProduct(v2.at(i));
+  }
+
+  return InputOutputVolume(v_result);
+}

--- a/neural_networks/conv_structs.hpp
+++ b/neural_networks/conv_structs.hpp
@@ -67,3 +67,8 @@ ConvKernels GetRandomConvKernels(const std::size_t num_kernels,
 InputOutputVolume GetRandomInputOutputVolume(const std::size_t num_channels,
                                              const std::size_t num_rows,
                                              const std::size_t num_cols);
+
+// Element-wise product of InputOutputVolumes
+InputOutputVolume operator*(const InputOutputVolume& volume_1,
+                            const InputOutputVolume& volume_2);
+

--- a/neural_networks/conv_structs.hpp
+++ b/neural_networks/conv_structs.hpp
@@ -42,6 +42,10 @@ class InputOutputVolume {
 
   const std::vector<Eigen::MatrixXd>& GetVolume() const { return volume_; }
 
+  // TODO: Work towards a design that does not require this by being able to
+  // perform operations directly on InputOutputVolumes, including reshaping.
+  Eigen::VectorXd GetVolumeVec() const;
+
   std::vector<double> GetValues() const;
 
   // Assume that volume_ is populated and dimensionally consistent.

--- a/neural_networks/conv_tests.cpp
+++ b/neural_networks/conv_tests.cpp
@@ -286,23 +286,21 @@ Eigen::VectorXd TestConvNetMultiConv(
 
   Eigen::MatrixXd dydl3pre = dydl3post * dl3postdl3pre;
 
-  Eigen::MatrixXd dl3predw3 = l2_post_act.transpose();
+  Eigen::MatrixXd dl3predw3 = l2_post_act;
 
-  Eigen::MatrixXd dydw3 = dydl3pre * dl3predw3;
+  Eigen::MatrixXd dydw3 = dl3predw3 * dydl3pre;
 
   Eigen::MatrixXd dl3predl2post = W3;
 
-  // dy/dl2 = dy / dl3  * dl3 / dl2
-  Eigen::MatrixXd dydw2 =
-      conv_1_output_post_act_vec * l3_post_act_grad * W3 * l2_post_act_grad;
+  Eigen::MatrixXd dl2predw2 = conv_1_output_post_act_vec;
 
   Eigen::MatrixXd dydl2post = dydl3pre * dl3predl2post;
-
-  // Eigen::MatrixXd dl2dl1 = l2_post_act_grad * W2;
 
   Eigen::MatrixXd dl2postdl2pre = l2_post_act_grad;
 
   Eigen::MatrixXd dydl2pre = dydl2post * dl2postdl2pre;
+
+  Eigen::MatrixXd dydw2 = dl2predw2 * dydl2pre;
 
   Eigen::MatrixXd dl2predl1post = W2;
 
@@ -310,12 +308,7 @@ Eigen::VectorXd TestConvNetMultiConv(
 
   Eigen::MatrixXd dl1postdl1pre = conv_1_output_post_act_grad_vec.asDiagonal();
 
-  // Eigen::MatrixXd dydl1 =
-  //     dydl3 * dl3dl2 * dl2dl1 * conv_1_output_post_act_grad_vec.asDiagonal();
-
   Eigen::MatrixXd dydl1pre = dydl1post * dl1postdl1pre;
-
-  // Eigen::MatrixXd dydl1 = dydl1pre;
 
   // The values in dydl1pre must be backpropagated through the right kernels, so
   // we need to reshape the elements correctly to work with them as kernels.
@@ -358,8 +351,6 @@ Eigen::VectorXd TestConvNetMultiConv(
   const std::vector<Eigen::MatrixXd> dydl0post_volume =
       ConvGradient(conv_kernels_1, dydl1pre_volume);
 
-  // Incorporate the effect of the activation gradient.
-  // TODO: It seems weird that this step comes after the convolution...
   const InputOutputVolume dydl0post_iov(dydl0post_volume);
   const InputOutputVolume dydl0pre_iov =
       conv_0_output_post_act_grad * dydl0post_iov;  // Element-wise product.

--- a/neural_networks/conv_tests.cpp
+++ b/neural_networks/conv_tests.cpp
@@ -117,8 +117,9 @@ void TestConvNetGradientsMultiConv() {
     std::vector<double> kernel_weights_1_perturbed = kernel_weights_1;
     kernel_weights_1_perturbed.at(i) += delta;
     const ConvKernels conv_kernels_1_perturbed(
-        kernel_weights_1_perturbed, num_kernels, num_kernels, num_rows_kernel,
-        num_cols_kernel);
+        kernel_weights_1_perturbed, conv_kernels_1.GetNumKernels(),
+        conv_kernels_1.GetNumChannels(), conv_kernels_1.GetNumRows(),
+        conv_kernels_1.GetNumCols());
 
     // Evaluate network.
     std::vector<Eigen::MatrixXd> d_output_d_kernel_delta;
@@ -143,8 +144,9 @@ void TestConvNetGradientsMultiConv() {
     std::vector<double> kernel_weights_2_perturbed = kernel_weights_2;
     kernel_weights_2_perturbed.at(i) += delta;
     const ConvKernels conv_kernels_2_perturbed(
-        kernel_weights_2_perturbed, num_kernels, num_kernels, num_rows_kernel,
-        num_cols_kernel);
+        kernel_weights_2_perturbed, conv_kernels_2.GetNumKernels(),
+        conv_kernels_2.GetNumChannels(), conv_kernels_2.GetNumRows(),
+        conv_kernels_2.GetNumCols());
 
     // Evaluate network.
     std::vector<Eigen::MatrixXd> d_output_d_kernel_delta;

--- a/neural_networks/conv_tests.cpp
+++ b/neural_networks/conv_tests.cpp
@@ -274,7 +274,8 @@ Eigen::VectorXd TestConvNetMultiConv(
   // Network:
   // Pre/Post indicate before/after activation
   //
-  //                l0pre   l0post   l1pre   l1post l2pre   l2post l3pre l3post
+  //              l0pre   l0post   l1pre   l1post l2pre   l2post l3pre   l3post
+  //                |       |        |       |      |       |      |       |
   // Input -> Conv0 -> Act0 -> Conv1 -> Act1 -> Fc2 -> Act2 -> Fc3 -> Act3 -> Y
   //          W0               W1               W2             W3
 

--- a/neural_networks/conv_tests.cpp
+++ b/neural_networks/conv_tests.cpp
@@ -271,6 +271,13 @@ Eigen::VectorXd TestConvNetMultiConv(
   const Eigen::VectorXd l3_post_act =
       Activation(l3_pre_act, ActivationFunction::SIGMOID, &l3_post_act_grad);
 
+  // Network:
+  // Pre/Post indicate before/after activation
+  //
+  //                l0pre   l0post   l1pre   l1post l2pre   l2post l3pre l3post
+  // Input -> Conv0 -> Act0 -> Conv1 -> Act1 -> Fc2 -> Act2 -> Fc3 -> Act3 -> Y
+  //          W0               W1               W2             W3
+
   // Compute gradients.
   Eigen::MatrixXd dydw3 = l3_post_act_grad * l2_post_act.transpose();
 

--- a/neural_networks/conv_tests.cpp
+++ b/neural_networks/conv_tests.cpp
@@ -211,7 +211,6 @@ Eigen::VectorXd TestConvNetMultiConv(
   const int stride = 1;
 
   InputOutputVolume conv_0_output_post_act;
-  // Eigen::MatrixXd conv_0_output_post_act_grad;
   InputOutputVolume conv_0_output_post_act_grad;
   std::vector<Eigen::MatrixXd> conv_0_input_mat;
 
@@ -228,21 +227,6 @@ Eigen::VectorXd TestConvNetMultiConv(
     conv_0_output_post_act =
         Activation(conv_output_volume, ActivationFunction::SIGMOID,
                    &conv_0_output_post_act_grad);
-
-    // const std::vector<double> conv_output_buf =
-    // conv_output_volume.GetValues(); const Eigen::VectorXd& conv_output =
-    // Eigen::Map<const Eigen::VectorXd>(
-    //     conv_output_buf.data(), conv_output_buf.size());
-    // const Eigen::VectorXd conv_0_output_post_act_vec = Activation(
-    //     conv_output, ActivationFunction::SIGMOID,
-    //     &conv_0_output_post_act_grad);
-    // const std::vector<double> conv_0_output_post_act_buf(
-    //     conv_0_output_post_act_vec.data(),
-    //     conv_0_output_post_act_vec.data() +
-    //     conv_0_output_post_act_vec.size());
-    // conv_0_output_post_act = InputOutputVolume(
-    //     conv_0_output_post_act_buf, conv_output_volume.GetNumChannels(),
-    //     conv_output_volume.GetNumRows(), conv_output_volume.GetNumCols());
   }
 
   Eigen::VectorXd conv_1_output_post_act;
@@ -411,37 +395,10 @@ Eigen::VectorXd TestConvNetMultiConv(
     }
   }
 
-  // Unwrap output_volume_dydl0 and multiply by conv_0_output_post_act_grad.
-  // std::vector<Eigen::MatrixXd> output_volume_dydl0_post_act;
-  // {
-  //   const int num_channel_dydl0 = output_volume_dydl0.size();
-  //   const int num_rows_per_channel_dydl0 =
-  //   output_volume_dydl0.front().rows(); const int num_cols_per_channel_dydl0
-  //   = output_volume_dydl0.front().cols(); const int num_per_channel_dydl0 =
-  //   output_volume_dydl0.front().size(); Eigen::VectorXd dydl0_vec =
-  //       Eigen::VectorXd::Zero(num_channel_dydl0 * num_per_channel_dydl0);
-  //   for (std::size_t i = 0; i < num_channel_dydl0; ++i) {
-  //     const Eigen::MatrixXd& m = output_volume_dydl0.at(i);
-  //     const Eigen::VectorXd m_vec =
-  //         Eigen::Map<const Eigen::VectorXd>(m.data(), m.size());
-  //     dydl0_vec.segment(i * num_per_channel_dydl0, num_per_channel_dydl0) =
-  //         m_vec;
-  //   }
-  //   const Eigen::VectorXd dydl0_vec_post_act =
-  //       conv_0_output_post_act_grad * dydl0_vec;
-  //
-  //   // Wrap back into matrices.
-  //   for (std::size_t i = 0; i < num_channel_dydl0; ++i) {
-  //     const Eigen::VectorXd& n = dydl0_vec_post_act.segment(
-  //         i * num_per_channel_dydl0, num_per_channel_dydl0);
-  //     const Eigen::MatrixXd o = Eigen::Map<const Eigen::MatrixXd>(
-  //         n.data(), num_rows_per_channel_dydl0, num_cols_per_channel_dydl0);
-  //     output_volume_dydl0_post_act.emplace_back(o);
-  //   }
-  // }
-
+  // Multiply dydl0 with conv_0_output_post_act_grad.
   std::vector<Eigen::MatrixXd> output_volume_dydl0_post_act;
   {
+    // TODO: Have previous stage output an InputOutputVolume directly.
     const InputOutputVolume dydl0_iov(output_volume_dydl0);
 
     // Element-wise product.

--- a/neural_networks/conv_tests.cpp
+++ b/neural_networks/conv_tests.cpp
@@ -429,7 +429,7 @@ Eigen::VectorXd TestConvNetMultiConv(
     }
   }
 
-  // Wrap conv_0_output_post_act_grad into a matrix of stacked columns, where
+  // Wrap conv_0_output_post_act into a matrix of stacked columns, where
   // each column corresponds to a kernel and multiply it by each element of
   // conv_0_input_mat in a loop.
   const std::size_t num_kernels_0 = conv_kernels_0.GetNumKernels();

--- a/neural_networks/conv_tests.cpp
+++ b/neural_networks/conv_tests.cpp
@@ -392,7 +392,11 @@ Eigen::VectorXd TestConvNetMultiConv(
       // Is it true that this will always be a single "channel"? This number
       // is the number of "kernels" (dydl1
       assert(output_volume_iteration.size() == 1);
-      output_volume_dydl0.emplace_back(output_volume_iteration.front());
+      output_volume_dydl0.emplace_back(output_volume_iteration.front()
+                                           .rowwise()
+                                           .reverse()
+                                           .colwise()
+                                           .reverse());
     }
   }
 

--- a/neural_networks/conv_tests.cpp
+++ b/neural_networks/conv_tests.cpp
@@ -218,9 +218,6 @@ Eigen::VectorXd TestConvNetMultiConv(
         conv_output_buf.data(), conv_output_buf.size());
     conv_1_output_post_act = Activation(
         conv_output, ActivationFunction::SIGMOID, &conv_1_output_post_act_grad);
-
-    // std::cerr << "Layer 1 conv output " << conv_output_volume.GetNumRows()
-    //           << " " << conv_output_volume.GetNumCols() << std::endl;
   }
 
   // Fully connected layer.
@@ -267,9 +264,6 @@ Eigen::VectorXd TestConvNetMultiConv(
   assert(dydl1_cols % num_kernels_1 == 0);
   assert(num_dydl1_per_kernel == conv_1_input_mat.front().cols());
 
-  // std::cerr << "dydl1: " << dydl1.rows() << ", " << dydl1.cols() <<
-  // std::endl;
-
   // Wrap values of dydl1 into a matrix where each row corresponds to a kernel.
   // TODO: The wrapping below won't work if dydl1 has multiple rows (e.g., y,
   // the output of the network, is multidimensional).
@@ -315,15 +309,6 @@ Eigen::VectorXd TestConvNetMultiConv(
     output_volume_dydl1.emplace_back(c);
   }
 
-  // if (print) {
-  //   std::cerr << "Backprop Layer 1 output channels: "
-  //             << output_volume_dydl1.front().size() << std::endl;
-  //   std::cerr << "Backprop Layer 1 number of channels per kernel: "
-  //             << conv_kernels_1.GetNumChannels() << std::endl;
-  //   std::cerr << "Backprop Layer 1 number of kernels: "
-  //             << conv_kernels_1.GetNumKernels() << std::endl;
-  // }
-
   // Compute dydl0
   //
   // Convolve L1 kernels (input) with dydl1 gradients (kernels)
@@ -337,13 +322,6 @@ Eigen::VectorXd TestConvNetMultiConv(
     const std::vector<std::vector<Eigen::MatrixXd>>& ck1 =
         conv_kernels_1.GetKernels();
     const std::size_t num_channels_per_kernel_1 = ck1.front().size();
-    // for (std::size_t i = 0; i < num_kernels_1; ++i) {
-    //   const std::vector<Eigen::MatrixXd>& ck11 = ck1.at(i);
-    //   std::vector<Eigen::MatrixXd> input_volume_foo;
-    //   for (const Eigen::MatrixXd& k : ck11) {
-    //     input_volume_foo.emplace_back(
-    //         k.rowwise().reverse().colwise().reverse());
-    //   }
 
     // TODO: Either of these loops over channels or kernels may need to reverse
     // (just as we flipped the filters themselves)...or not.
@@ -390,91 +368,6 @@ Eigen::VectorXd TestConvNetMultiConv(
     }
   }
 
-  // if (print) {
-  //   std::cerr << "dydl0:" << std::endl;
-  //   for (const auto& d : output_volume_dydl0) {
-  //     std::cerr << std::endl;
-  //     std::cerr << d << std::endl;
-  //   }
-  // }
-
-  /////////////////////////////
-  //
-  //
-  //
-  // Wrap values of dydl1 into a matrix where each row corresponds to a kernel.
-  // TODO: The wrapping below won't work if dydl1 has multiple rows (e.g., y,
-  // the output of the network, is multidimensional).
-  //
-  // assert(dydl1.rows() == 1);
-  // Eigen::MatrixXd dydl1_wrapped = Eigen::Map<Eigen::MatrixXd>(
-  //     dydl1.data(), num_dydl1_per_kernel, num_kernels_1);
-  //
-  // Don't forget that this is also a convolution!  TODO: See if we can avoid
-  // looping over kernels if we can compute convolution with each kernel
-  // simultaneously via matrix multiplication, whether the unrolled
-  // weight/kernel vector is a matrix of unrolled kernels stacked together.
-  //
-  // std::vector<Eigen::MatrixXd> dydw1_kernels;
-  // for (std::size_t i = 0; i < num_kernels_1; ++i) {
-  //   dydw1_kernels.emplace_back(conv_1_input_mat.at(i) * dydl1_wrapped);
-  // }
-  //
-  //
-  //
-  //
-  // Eigen::MatrixXd dydl0 =
-  //     output_volume_dydl0.front().rowwise().reverse().colwise().reverse();
-  //
-  // const Eigen::VectorXd dydl0_vec =
-  //     Eigen::Map<Eigen::VectorXd>(dydl0.data(), dydl0.size());
-  //
-  // const Eigen::VectorXd dydl0_vec_post_act =
-  //     conv_0_output_post_act_grad * dydl0_vec;
-  //
-  // Don't forget that this is also a convolution!
-  // TODO: Only works with single channel.
-  // Eigen::MatrixXd dydw0 = conv_0_input_mat.front() * dydl0_vec_post_act;
-  //     Eigen::Map<Eigen::VectorXd>(dydl0.data(), dydl0.size()) *
-  //     conv_0_input_mat.front().transpose();
-  //
-  //
-  //
-
-  // Have:
-  // output_volume_dydl0
-  // conv_0_output_post_act_grad
-
-  // Need:
-  // dydl0_vec_post_act
-
-  // if (print) {
-  //   std::cerr << "Number of elements in output_volume_dydl0: "
-  //             << output_volume_dydl0.size() << std::endl;
-  //   std::cerr << "Size of each element in output_volume_dydl0: "
-  //             << output_volume_dydl0.front().rows() << " "
-  //             << output_volume_dydl0.front().cols() << std::endl;
-  //   std::cerr << "Number of elements in conv_0_output_post_act_grad: "
-  //             << conv_0_output_post_act_grad.rows() << " "
-  //             << conv_0_output_post_act_grad.cols() << std::endl;
-  // }
-
-  // std::vector<Eigen::MatrixXd> dydw0_kernels;
-  // for (std::size_t i = 0; i < num_kernels_0; ++i) {
-  //   dydw0_kernels.emplace_back(conv_0_input_mat.at(i) * dydl0_wrapped);
-  // }
-
-  //
-  //
-  /////////////////////////////
-
-  // std::cerr << "Depth of dydl0: " << conv_0_output_post_act.GetNumChannels()
-  //           << std::endl;
-  // std::cerr << "Rows of dydl0:  " << conv_0_output_post_act.GetNumRows()
-  //           << std::endl;
-  // std::cerr << "Cols of dydl0:  " << conv_0_output_post_act.GetNumCols()
-  //           << std::endl;
-
   // Unwrap output_volume_dydl0 and multiply by conv_0_output_post_act_grad.
   std::vector<Eigen::MatrixXd> output_volume_dydl0_post_act;
   {
@@ -504,34 +397,9 @@ Eigen::VectorXd TestConvNetMultiConv(
     }
   }
 
-  if (print) {
-    std::cerr << "conv 0 input mat: " << conv_0_input_mat.size() << std::endl;
-    std::cerr << "conv 0 input mat element size: "
-              << conv_0_input_mat.front().rows() << " "
-              << conv_0_input_mat.front().cols() << std::endl;
-    std::cerr << "output_volume_dydl0_post_act: "
-              << output_volume_dydl0_post_act.size() << std::endl;
-    std::cerr << "output_volume_dydl0_post_act element: "
-              << output_volume_dydl0_post_act.front().rows() << " "
-              << output_volume_dydl0_post_act.front().cols() << std::endl;
-
-    // std::cerr << "Size of each element in output_volume_dydl0: "
-    //           << output_volume_dydl0.front().rows() << " "
-    //           << output_volume_dydl0.front().cols() << std::endl;
-    // std::cerr << "Number of elements in conv_0_output_post_act_grad: "
-    //           << conv_0_output_post_act_grad.rows() << " "
-    //           << conv_0_output_post_act_grad.cols() << std::endl;
-  }
-
-  // Using this:
-  //
-  // Eigen::MatrixXd dydl1_wrapped = Eigen::Map<Eigen::MatrixXd>(
-  //     dydl1.data(), num_dydl1_per_kernel, num_kernels_1);
-  //
   // Wrap conv_0_output_post_act_grad into a matrix of stacked columns, where
   // each column corresponds to a kernel and multiply it by each element of
   // conv_0_input_mat in a loop.
-
   const std::size_t num_kernels_0 = conv_kernels_0.GetNumKernels();
   Eigen::MatrixXd dydl0_wrapped = Eigen::MatrixXd::Zero(
       output_volume_dydl0_post_act.front().size(), num_kernels_0);
@@ -553,25 +421,9 @@ Eigen::VectorXd TestConvNetMultiConv(
     }
   }
 
-  // if (print) {
-  //   std::cerr << "dydl0_wrapped: " << std::endl << dydl0_wrapped <<
-  //   std::endl;
-  // }
-
   // Convert output_volume_dydl0 container to an input/output volume
-  // std::vector<std::vector<Eigen::MatrixXd>> output_volume_dydl0_expanded{
-  //     output_volume_dydl0};
   std::vector<std::vector<Eigen::MatrixXd>> output_volume_dydl0_expanded{
       output_volume_dydl0_post_act};
-
-  // if (print) {
-  //   std::cerr << "Backprop Layer 0 output channels: "
-  //             << output_volume_dydl0_expanded.front().size() << std::endl;
-  //   std::cerr << "Backprop Layer 0 number of channels per kernel: "
-  //             << conv_kernels_0.GetNumChannels() << std::endl;
-  //   std::cerr << "Backprop Layer 0 number of kernels: "
-  //             << conv_kernels_0.GetNumKernels() << std::endl;
-  // }
 
   std::vector<Eigen::MatrixXd> output_volume_dydlinput;
   {

--- a/neural_networks/conv_tests.cpp
+++ b/neural_networks/conv_tests.cpp
@@ -50,14 +50,14 @@ void TestConvNetGradientsMultiConv() {
   const std::size_t stride = 1;
 
   // Randomly generate input.
-  const std::size_t num_channels_input = 1;
-  const std::size_t num_rows_input = 3;
-  const std::size_t num_cols_input = 3;
+  const std::size_t num_channels_input = 2;
+  const std::size_t num_rows_input = 5;
+  const std::size_t num_cols_input = 5;
   const InputOutputVolume input_volume = GetRandomInputOutputVolume(
       num_channels_input, num_rows_input, num_cols_input);
 
   // Randomly generate conv layer weights.
-  const std::size_t num_kernels = 1;
+  const std::size_t num_kernels = 3;
   const std::size_t num_rows_kernel = 2;
   const std::size_t num_cols_kernel = 2;
   const ConvKernels conv_kernels_1 = GetRandomConvKernels(
@@ -304,6 +304,9 @@ Eigen::VectorXd TestConvNetMultiConv(
   // Wrap values of dydl1 into a matrix where each row corresponds to a kernel.
   // TODO: The wrapping below won't work if dydl1 has multiple rows (e.g., y,
   // the output of the network, is multidimensional).
+  //
+  // TODO: This reshaping should already be happening in
+  // ConvMatrixMultiplication for calculating dydl0 below.
   assert(dydl1.rows() == 1);
   Eigen::MatrixXd dydl1_wrapped = Eigen::Map<Eigen::MatrixXd>(
       dydl1.data(), num_dydl1_per_kernel, num_kernels_1);

--- a/neural_networks/conv_tests.cpp
+++ b/neural_networks/conv_tests.cpp
@@ -285,57 +285,8 @@ Eigen::VectorXd TestConvNetMultiConv(
 
   Eigen::MatrixXd dl2dl1 = l2_post_act_grad * W2;
 
-  // TODO: Only works with single channel.
-  // Eigen::MatrixXd dydw1 = dydl3 * dl3dl2 * dl2dl1 *
-  //                         conv_1_output_post_act_grad *
-  //                         conv_1_input_mat.front().transpose();
-
   Eigen::MatrixXd dydl1 =
       dydl3 * dl3dl2 * dl2dl1 * conv_1_output_post_act_grad_vec.asDiagonal();
-
-  // The values in dydl1 must be backpropagated through the right kernels.
-  //
-  // // TODO: dydl1_cols should be evenly divisible by the number of channels of
-  // // the l1 output volume (e.g., number of kernels in L1).
-  // const std::size_t dydl1_cols = dydl1.cols();
-  // const std::size_t num_kernels_1 = conv_kernels_1.GetNumKernels();
-  // const std::size_t num_dydl1_per_kernel = dydl1_cols / num_kernels_1;
-  // assert(dydl1_cols % num_kernels_1 == 0);
-  // assert(num_dydl1_per_kernel == conv_1_input_mat.front().cols());
-  //
-  // // Wrap values of dydl1 into a matrix where each row corresponds to a
-  // kernel.
-  // // TODO: The wrapping below won't work if dydl1 has multiple rows (e.g., y,
-  // // the output of the network, is multidimensional).
-  // //
-  // // TODO: This reshaping should already be happening in
-  // // ConvMatrixMultiplication for calculating dydl0 below.
-  // assert(dydl1.rows() == 1);
-  // Eigen::MatrixXd dydl1_wrapped = Eigen::Map<Eigen::MatrixXd>(
-  //     dydl1.data(), num_dydl1_per_kernel, num_kernels_1);
-
-  // // Don't forget that this is also a convolution!
-  // // TODO: See if we can avoid looping over kernels if we can compute
-  // // convolution with each kernel simultaneously via matrix multiplication,
-  // // whether the unrolled weight/kernel vector is a matrix of unrolled
-  // kernels
-  // // stacked together.
-  // std::vector<Eigen::MatrixXd> dydw1_kernels;
-  // for (std::size_t i = 0; i < num_kernels_1; ++i) {
-  //   dydw1_kernels.emplace_back(conv_1_input_mat.at(i) * dydl1_wrapped);
-  // }
-  //
-  // if (print) {
-  //   std::cerr << "dydw1" << std::endl;
-  //   for (const auto& dydw : dydw1_kernels) {
-  //     std::cerr << dydw << std::endl;
-  //     std::cerr << std::endl;
-  //   }
-  // }
-
-  // Don't forget that this is also a convolution!
-  // TODO: Only works with single channel.
-  // Eigen::MatrixXd dydw1 = dydl1 * conv_1_input_mat.front().transpose();
 
   // The values in dydl1 must be backpropagated through the right kernels, so we
   // need to reshape elements of dydl1 correctly to work with them as kernels.

--- a/neural_networks/conv_tests.cpp
+++ b/neural_networks/conv_tests.cpp
@@ -176,11 +176,6 @@ Eigen::VectorXd TestConvNetMultiConv(
   const int padding = 0;
   const int stride = 1;
 
-  if (print) {
-    std::cerr << "Input channels: " << input_volume.GetNumChannels()
-              << std::endl;
-  }
-
   InputOutputVolume conv_0_output_post_act;
   Eigen::MatrixXd conv_0_output_post_act_grad;
   std::vector<Eigen::MatrixXd> conv_0_input_mat;
@@ -205,11 +200,6 @@ Eigen::VectorXd TestConvNetMultiConv(
         conv_output_volume.GetNumRows(), conv_output_volume.GetNumCols());
   }
 
-  if (print) {
-    std::cerr << "Layer 0 output channels: "
-              << conv_0_output_post_act.GetNumChannels() << std::endl;
-  }
-
   Eigen::VectorXd conv_1_output_post_act;
   Eigen::MatrixXd conv_1_output_post_act_grad;
   std::vector<Eigen::MatrixXd> conv_1_input_mat;
@@ -226,11 +216,6 @@ Eigen::VectorXd TestConvNetMultiConv(
         conv_output_buf.data(), conv_output_buf.size());
     conv_1_output_post_act = Activation(
         conv_output, ActivationFunction::SIGMOID, &conv_1_output_post_act_grad);
-
-    if (print) {
-      std::cerr << "Layer 1 output channels: "
-                << conv_output_volume.GetNumChannels() << std::endl;
-    }
 
     // std::cerr << "Layer 1 conv output " << conv_output_volume.GetNumRows()
     //           << " " << conv_output_volume.GetNumCols() << std::endl;
@@ -320,14 +305,14 @@ Eigen::VectorXd TestConvNetMultiConv(
     output_volume_dydl1.emplace_back(c);
   }
 
-  if (print) {
-    std::cerr << "Backprop Layer 1 output channels: "
-              << output_volume_dydl1.front().size() << std::endl;
-    std::cerr << "Backprop Layer 1 number of channels per kernel: "
-              << conv_kernels_1.GetNumChannels() << std::endl;
-    std::cerr << "Backprop Layer 1 number of kernels: "
-              << conv_kernels_1.GetNumKernels() << std::endl;
-  }
+  // if (print) {
+  //   std::cerr << "Backprop Layer 1 output channels: "
+  //             << output_volume_dydl1.front().size() << std::endl;
+  //   std::cerr << "Backprop Layer 1 number of channels per kernel: "
+  //             << conv_kernels_1.GetNumChannels() << std::endl;
+  //   std::cerr << "Backprop Layer 1 number of kernels: "
+  //             << conv_kernels_1.GetNumKernels() << std::endl;
+  // }
 
   // Compute dydl0
   //
@@ -351,15 +336,10 @@ Eigen::VectorXd TestConvNetMultiConv(
     //   }
 
     // TODO: Either of these loops over channels or kernels may need to reverse
-    // (just as we flipped the filters themselves).
-    if (print) {
-      std::cerr << "Don't forget to try reversing order" << std::endl;
-    }
+    // (just as we flipped the filters themselves)...or not.
     for (std::size_t j = 0; j < num_channels_per_kernel_1; ++j) {
-      // for (int j = num_channels_per_kernel_1 - 1; j >= 0; --j) {
       std::vector<Eigen::MatrixXd> input_volume_foo;
       for (std::size_t i = 0; i < num_kernels_1; ++i) {
-        // for (int i = num_kernels_1 - 1; i >= 0; --i) {
         const Eigen::MatrixXd& ck111 = ck1.at(i).at(j);
         input_volume_foo.emplace_back(
             ck111.rowwise().reverse().colwise().reverse());
@@ -400,13 +380,13 @@ Eigen::VectorXd TestConvNetMultiConv(
     }
   }
 
-  if (print) {
-    std::cerr << "dydl0:" << std::endl;
-    for (const auto& d : output_volume_dydl0) {
-      std::cerr << std::endl;
-      std::cerr << d << std::endl;
-    }
-  }
+  // if (print) {
+  //   std::cerr << "dydl0:" << std::endl;
+  //   for (const auto& d : output_volume_dydl0) {
+  //     std::cerr << std::endl;
+  //     std::cerr << d << std::endl;
+  //   }
+  // }
 
   // std::cerr << "Depth of dydl0: " << conv_0_output_post_act.GetNumChannels()
   //           << std::endl;
@@ -450,14 +430,14 @@ Eigen::VectorXd TestConvNetMultiConv(
   std::vector<std::vector<Eigen::MatrixXd>> output_volume_dydl0_expanded{
       output_volume_dydl0_post_act};
 
-  if (print) {
-    std::cerr << "Backprop Layer 0 output channels: "
-              << output_volume_dydl0_expanded.front().size() << std::endl;
-    std::cerr << "Backprop Layer 0 number of channels per kernel: "
-              << conv_kernels_0.GetNumChannels() << std::endl;
-    std::cerr << "Backprop Layer 0 number of kernels: "
-              << conv_kernels_0.GetNumKernels() << std::endl;
-  }
+  // if (print) {
+  //   std::cerr << "Backprop Layer 0 output channels: "
+  //             << output_volume_dydl0_expanded.front().size() << std::endl;
+  //   std::cerr << "Backprop Layer 0 number of channels per kernel: "
+  //             << conv_kernels_0.GetNumChannels() << std::endl;
+  //   std::cerr << "Backprop Layer 0 number of kernels: "
+  //             << conv_kernels_0.GetNumKernels() << std::endl;
+  // }
 
   const std::size_t num_kernels_0 = conv_kernels_0.GetNumKernels();
   std::vector<Eigen::MatrixXd> output_volume_dydlinput;
@@ -468,15 +448,10 @@ Eigen::VectorXd TestConvNetMultiConv(
     const std::size_t num_channels_per_kernel_0 = ck0.front().size();
 
     // TODO: Either of these loops over channels or kernels may need to reverse
-    // (just as we flipped the filters themselves).
-    if (print) {
-      std::cerr << "Don't forget to try reversing order" << std::endl;
-    }
+    // (just as we flipped the filters themselves)...or not.
     for (std::size_t j = 0; j < num_channels_per_kernel_0; ++j) {
-      // for (int j = num_channels_per_kernel_0 - 1; j >= 0; --j) {
       std::vector<Eigen::MatrixXd> input_volume_foo;
       for (std::size_t i = 0; i < num_kernels_0; ++i) {
-        // for (int i = num_kernels_0 - 1; i >= 0; --i) {
         const Eigen::MatrixXd& ck000 = ck0.at(i).at(j);
         input_volume_foo.emplace_back(
             ck000.rowwise().reverse().colwise().reverse());
@@ -524,113 +499,6 @@ Eigen::VectorXd TestConvNetMultiConv(
       std::cerr << d << std::endl;
     }
   }
-
-  return l3_post_act;
-  //
-  //   std::vector<Eigen::MatrixXd> input_channels_unrolled_return;
-  //   const std::vector<double> biases{0};
-  //
-  //   // TODO: Currently only works with square kernels and inputs due to the
-  //   // padding required for a full convolution.
-  //   assert(f.rows() == f.cols());
-  //   assert(dydl1_reshaped.rows() == dydl1_reshaped.cols());
-  //
-  //   const std::size_t input_volume_rows = f.rows();
-  //   const std::size_t input_volume_cols = f.cols();
-  //   const std::size_t conv_kernels_rows = dydl1_reshaped.rows();
-  //   const std::size_t conv_kernels_cols = dydl1_reshaped.cols();
-  //
-  //   // NOTE: "Full convolution" involves sweeping the filter all the way
-  //   across,
-  //   // max possible overlap, which can be achieved by doing a "normal"
-  //   // convolution with a padded input.
-  //   const std::size_t full_conv_padding = conv_kernels_rows - 1;
-  //   ConvMatrixMultiplication(input_volume, conv_kernels, biases,
-  //                            full_conv_padding, 1, &output_volume_dydl0,
-  //                            &input_channels_unrolled_return);
-  // }
-  // Eigen::MatrixXd dydl0 =
-  //     output_volume_dydl0.front().rowwise().reverse().colwise().reverse();
-  //
-  // const Eigen::VectorXd dydl0_vec =
-  //     Eigen::Map<Eigen::VectorXd>(dydl0.data(), dydl0.size());
-  //
-  // const Eigen::VectorXd dydl0_vec_post_act =
-  //     conv_0_output_post_act_grad * dydl0_vec;
-  //
-  // // Don't forget that this is also a convolution!
-  // // TODO: Only works with single channel.
-  // Eigen::MatrixXd dydw0 = conv_0_input_mat.front() * dydl0_vec_post_act;
-  // //     Eigen::Map<Eigen::VectorXd>(dydl0.data(), dydl0.size()) *
-  // //     conv_0_input_mat.front().transpose();
-  //
-  // if (print) {
-  //   std::cerr << "dydw0" << std::endl;
-  //   std::cerr << dydw0 << std::endl;
-  //   std::cerr << std::endl;
-  // }
-  //
-  // // Compute dydinput
-  // std::vector<Eigen::MatrixXd> output_volume_dydinput;
-  // {
-  //   // // Shape of l0 output is a conv output volume.
-  //   // const Eigen::VectorXd dydl0_vec =
-  //   //     Eigen::Map<const Eigen::VectorXd>(dydl0.data(), dydl0.size());
-  //   // const Eigen::VectorXd dydl0_vec_post_act =
-  //   //     conv_0_output_post_act_grad * dydl0_vec;
-  //   const Eigen::MatrixXd dydl0_reshaped = Eigen::Map<const Eigen::MatrixXd>(
-  //       dydl0_vec_post_act.data(), num_steps_vertical_0,
-  //       num_steps_horizontal_0);
-  //   // Eigen::MatrixXd dydl0_reshaped =
-  //   //     dydl0;  // Already correct shape since it's conv output.
-  //
-  //   // if (print) {
-  //   //   std::cerr << "foo" << std::endl;
-  //   //   std::cerr << dydl0 << std::endl;
-  //   //   std::cerr << std::endl;
-  //   //   std::cerr << dydl0_reshaped << std::endl;
-  //   // }
-  //
-  //   // "Full convolution" between dydl0_reshaped and conv_kernels_0
-  //   // (flipped?).
-  //   Eigen::MatrixXd f = conv_kernels_0.GetKernels()
-  //                           .front()
-  //                           .front()
-  //                           .rowwise()
-  //                           .reverse()
-  //                           .colwise()
-  //                           .reverse();
-  //   const std::vector<Eigen::MatrixXd> input_volume{f};
-  //   const std::vector<std::vector<Eigen::MatrixXd>> conv_kernels{
-  //       {dydl0_reshaped}};
-  //   std::vector<Eigen::MatrixXd> input_channels_unrolled_return;
-  //   const std::vector<double> biases{0};
-  //
-  //   // TODO: Currently only works with square kernels and inputs due to the
-  //   // padding required for a full convolution.
-  //   assert(f.rows() == f.cols());
-  //   assert(dydl0_reshaped.rows() == dydl0_reshaped.cols());
-  //
-  //   const std::size_t input_volume_rows = f.rows();
-  //   const std::size_t input_volume_cols = f.cols();
-  //   const std::size_t conv_kernels_rows = dydl0_reshaped.rows();
-  //   const std::size_t conv_kernels_cols = dydl0_reshaped.cols();
-  //
-  //   // NOTE: "Full convolution" involves sweeping the filter all the way
-  //   // across, max possible overlap, which can be achieved by doing a
-  //   "normal"
-  //   // convolution with a padded input.
-  //   const std::size_t full_conv_padding = conv_kernels_rows - 1;
-  //   ConvMatrixMultiplication(input_volume, conv_kernels, biases,
-  //                            full_conv_padding, 1, &output_volume_dydinput,
-  //                            &input_channels_unrolled_return);
-  // }
-  // const Eigen::MatrixXd dydinput =
-  //     output_volume_dydinput.front().rowwise().reverse().colwise().reverse();
-  // if (print) {
-  //   std::cerr << "dydinput" << std::endl;
-  //   std::cerr << dydinput << std::endl;
-  // }
 
   return l3_post_act;
 }

--- a/neural_networks/conv_tests.cpp
+++ b/neural_networks/conv_tests.cpp
@@ -509,7 +509,11 @@ Eigen::VectorXd TestConvNetMultiConv(
       // Is it true that this will always be a single "channel"? This number
       // is the number of "kernels" (dydl0
       assert(output_volume_iteration.size() == 1);
-      output_volume_dydlinput.emplace_back(output_volume_iteration.front());
+      output_volume_dydlinput.emplace_back(output_volume_iteration.front()
+                                               .rowwise()
+                                               .reverse()
+                                               .colwise()
+                                               .reverse());
     }
   }
 

--- a/neural_networks/conv_tests.cpp
+++ b/neural_networks/conv_tests.cpp
@@ -292,13 +292,13 @@ Eigen::VectorXd TestConvNetMultiConv(
 
   Eigen::MatrixXd dl3predl2post = W3;
 
-  Eigen::MatrixXd dl2predw2 = conv_1_output_post_act_vec;
-
   Eigen::MatrixXd dydl2post = dydl3pre * dl3predl2post;
 
   Eigen::MatrixXd dl2postdl2pre = l2_post_act_grad;
 
   Eigen::MatrixXd dydl2pre = dydl2post * dl2postdl2pre;
+
+  Eigen::MatrixXd dl2predw2 = conv_1_output_post_act_vec;
 
   Eigen::MatrixXd dydw2 = dl2predw2 * dydl2pre;
 

--- a/neural_networks/conv_tests.hpp
+++ b/neural_networks/conv_tests.hpp
@@ -12,19 +12,6 @@ void TestConvKernels(const ConvExample& conv_example);
 void TestFullConv();
 
 /**
- * Put together a full network with multiple layers.
- */
-Eigen::VectorXd TestConvNet(const InputOutputVolume& input_volume,
-                            const ConvKernels& conv_kernels,
-                            const std::vector<double>& conv_biases,
-                            const Eigen::MatrixXd& W_out,
-                            const Eigen::VectorXd& b_out,
-                            const std::size_t num_steps_total, const bool print,
-                            std::vector<Eigen::MatrixXd>* d_output_d_kernel,
-                            Eigen::VectorXd* d_output_d_bias);
-void TestConvNetGradients();
-
-/**
  * Test setup with two conv layers. Work in progress...
  */
 Eigen::VectorXd TestConvNetMultiConv(


### PR DESCRIPTION
This PR implements a simple neural network with two convolution layers and two fully connected layers with working backpropagation of gradients.