### PR TITLE
Reduce memory allocation

### DIFF
--- a/neural_networks/conv.cpp
+++ b/neural_networks/conv.cpp
@@ -47,39 +47,22 @@ void Conv(const std::vector<Eigen::MatrixXd>& input_volume_unpadded,
     for (size_t j = 0; j < conv_kernel.size(); ++j) {
       const Eigen::MatrixXd& input_channel = input_volume.at(j);
       const Eigen::MatrixXd& kernel_channel = conv_kernel.at(j);
-
-      //   std::cerr << "Kernel channel:" << std::endl
-      // << kernel_channel << std::endl;
-
       for (size_t k = 0; k < num_steps_horizontal; ++k) {
         const size_t min_ind_col = k * stride;
         for (size_t l = 0; l < num_steps_vertical; ++l) {
           const size_t min_ind_row = l * stride;
 
           // Extract sub-matrix we want to multiply.
+          // NOTE: This line takes about 60% of this function's time.
           const Eigen::MatrixXd& input_region = input_channel.block(
               min_ind_row, min_ind_col, kernel_rows, kernel_cols);
 
-          // std::cerr << "Min row: " << min_ind_row << std::endl;
-          // std::cerr << "Min col: " << min_ind_col << std::endl;
-          // std::cerr << "l: " << l << std::endl;
-          // std::cerr << "k: " << k << std::endl;
-          // std::cerr << "input_region:" << std::endl
-          //     << input_region << std::endl;
-          // std::cin.get();
-
+          // NOTE: This line takes about 50% of this function's time.
           filter_channel_sum(l, k) +=
               input_region.cwiseProduct(kernel_channel).sum();
-          // std::cerr << "Filter Channel Sum:" << std::endl;
-          // std::cerr << filter_channel_sum << std::endl;
-          // std::cin.get();
         }
       }
     }
-
-    // std::cerr << "Filter Channel Sum:" << std::endl;
-    // std::cerr << filter_channel_sum << std::endl;
-    // std::cin.get();
     output_volume->emplace_back(filter_channel_sum);
   }
 }

--- a/neural_networks/layer.cpp
+++ b/neural_networks/layer.cpp
@@ -55,8 +55,7 @@ void LayerFC::ForwardPass(const std::vector<double>& input,
       pre_activation_vec.data() + pre_activation_vec.size());
 
   // Compute activation and gradient.
-  *output =
-      Activation(pre_activation, activation_function_, activation_gradient);
+  Activation(pre_activation, activation_function_, output, activation_gradient);
 }
 
 void LayerFC::BackwardPass(const std::vector<double>& input,
@@ -192,8 +191,7 @@ void LayerConv::ForwardPass(const std::vector<double>& input,
   }
 
   // Compute activation and gradient.
-  *output =
-      Activation(output_values, activation_function_, activation_gradient);
+  Activation(output_values, activation_function_, output, activation_gradient);
 }
 
 void LayerConv::BackwardPass(const std::vector<double>& input,

--- a/neural_networks/layer.cpp
+++ b/neural_networks/layer.cpp
@@ -88,6 +88,8 @@ void LayerFC::BackwardPass(const std::vector<double>& input,
                                             num_biases);
 
   assert(dloss_doutput.size() == num_outputs_);
+
+  // TODO: Change this to Eigen::Map<const Eigen::VectorXd> for efficency.
   const Eigen::Map<const Eigen::MatrixXd> dloss_doutput_mat(
       dloss_doutput.data(), 1, num_outputs_);
 
@@ -225,6 +227,9 @@ void LayerConv::BackwardPass(const std::vector<double>& input,
   const ConvKernels conv_kernels(kernel_parameters, num_kernels_,
                                  input_channels_, kernel_rows_, kernel_cols_);
 
+  // TODO: This matrix-vector multiplication is a bottleneck. Consider
+  // exploiting sparsity of activation_gradient, especially considering it's
+  // only dense for softmax activations, which we never use in a conv layer.
   const Eigen::VectorXd dloss_doutput_pre_act =
       Eigen::Map<const Eigen::MatrixXd>(activation_gradient.data(),
                                         dloss_doutput.size(),

--- a/neural_networks/network.cpp
+++ b/neural_networks/network.cpp
@@ -17,20 +17,20 @@ std::vector<double> Network::Evaluate(const std::vector<double>& input,
                                       const std::vector<double>& label,
                                       const std::vector<double>& parameters) {
   // TODO: Pre-allocate these containers and assert that their size is correct.
-  if (layer_io.size() != (layers_.size() + 1)) {
+  if (layer_io_.size() != (layers_.size() + 1)) {
     std::cerr << "Re-sizing layer IO container" << std::endl;
-    layer_io.resize(layers_.size() + 1);
+    layer_io_.resize(layers_.size() + 1);
   }
-  if (layer_activation_gradients.size() != (layers_.size() + 1)) {
+  if (layer_activation_gradients_.size() != (layers_.size() + 1)) {
     std::cerr << "Re-sizing layer activation gradients container" << std::endl;
-    layer_activation_gradients.resize(layers_.size() + 1);
+    layer_activation_gradients_.resize(layers_.size() + 1);
   }
 
   // Iterator indicating the beginning of the current layer's parameters.
   auto param_begin = parameters.begin();
 
   // Initialize input.
-  layer_io.front() = input;
+  layer_io_.front() = input;
 
   // Foward pass.
   for (std::size_t i = 0; i < layers_.size(); ++i) {
@@ -42,15 +42,15 @@ std::vector<double> Network::Evaluate(const std::vector<double>& input,
                                           param_begin + num_params);
 
     // Evaluate layer.
-    layer->ForwardPass(layer_io.at(i), layer_param, &layer_io.at(i + 1),
-                       &layer_activation_gradients.at(i));
+    layer->ForwardPass(layer_io_.at(i), layer_param, &layer_io_.at(i + 1),
+                       &layer_activation_gradients_.at(i));
 
     // Advance the param iterator.
     param_begin += num_params;
   }
 
   // TODO: Can also use layers_.back() if you confirm size is correct.
-  return layer_io.at(layers_.size());
+  return layer_io_.at(layers_.size());
 }
 
 double Network::Evaluate(const std::vector<double>& input,
@@ -65,17 +65,17 @@ double Network::Evaluate(const std::vector<double>& input,
   auto param_begin = parameters.begin();
 
   // TODO: Pre-allocate these containers and assert that their size is correct.
-  if (layer_io.size() != (layers_.size() + 1)) {
+  if (layer_io_.size() != (layers_.size() + 1)) {
     std::cerr << "Re-sizing layer IO container" << std::endl;
-    layer_io.resize(layers_.size() + 1);
+    layer_io_.resize(layers_.size() + 1);
   }
-  if (layer_activation_gradients.size() != (layers_.size() + 1)) {
+  if (layer_activation_gradients_.size() != (layers_.size() + 1)) {
     std::cerr << "Re-sizing layer activation gradients container" << std::endl;
-    layer_activation_gradients.resize(layers_.size() + 1);
+    layer_activation_gradients_.resize(layers_.size() + 1);
   }
 
   // Initialize input.
-  layer_io.front() = input;
+  layer_io_.front() = input;
 
   // Store the parameters.
   std::vector<std::vector<double>> layer_params;
@@ -90,8 +90,8 @@ double Network::Evaluate(const std::vector<double>& input,
                                           param_begin + num_params);
 
     // Evaluate layer.
-    layer->ForwardPass(layer_io.at(i), layer_param, &layer_io.at(i + 1),
-                       &layer_activation_gradients.at(i));
+    layer->ForwardPass(layer_io_.at(i), layer_param, &layer_io_.at(i + 1),
+                       &layer_activation_gradients_.at(i));
 
     // TODO: Reduce/avoid copies.
     layer_params.emplace_back(layer_param);
@@ -106,7 +106,7 @@ double Network::Evaluate(const std::vector<double>& input,
 
   // TODO: Can also use layers_.back() if you confirm size is correct.
   const Eigen::VectorXd network_output = Eigen::Map<Eigen::VectorXd>(
-      layer_io.at(layers_.size()).data(), layer_io.at(layers_.size()).size());
+      layer_io_.at(layers_.size()).data(), layer_io_.at(layers_.size()).size());
 
   Eigen::VectorXd loss_gradient;
   const Eigen::VectorXd loss =
@@ -132,10 +132,10 @@ double Network::Evaluate(const std::vector<double>& input,
     const LayerPtr& layer = layers_.at(i);
 
     // TODO: Avoid reusing variable names.
-    const std::vector<double>& layer_input = layer_io.at(i);
+    const std::vector<double>& layer_input = layer_io_.at(i);
     const std::vector<double>& layer_param = layer_params.at(i);
     const std::vector<double>& layer_act_grad =
-        layer_activation_gradients.at(i);
+        layer_activation_gradients_.at(i);
 
     std::vector<double> dloss_dnetwork_updated;
     std::vector<double> dloss_dparams;

--- a/neural_networks/network.cpp
+++ b/neural_networks/network.cpp
@@ -50,54 +50,55 @@ double Network::Evaluate(const std::vector<double>& input,
                          const std::vector<double>& parameters,
                          std::vector<double>* input_gradient,
                          std::vector<double>* param_gradient,
-                         NetworkTiming* timing) const {
+                         NetworkTiming* timing) {
   auto forward_pass_start = std::chrono::steady_clock::now();
 
   // Iterator indicating the beginning of the current layer's parameters.
   auto param_begin = parameters.begin();
 
+  // TODO: Pre-allocate these containers and assert that their size is correct.
+  if (layer_io.size() != (layers_.size() + 1)) {
+    std::cerr << "Re-sizing layer IO container" << std::endl;
+    layer_io.resize(layers_.size() + 1);
+  }
+  if (layer_activation_gradients.size() != (layers_.size() + 1)) {
+    std::cerr << "Re-sizing layer activation gradients container" << std::endl;
+    layer_activation_gradients.resize(layers_.size() + 1);
+  }
+
   // Initialize input.
-  std::vector<double> layer_input = input;
-
-  // Store the activation gradients from each layer during the forward pass.
-  std::vector<std::vector<double>> layer_activation_gradients;
-
-  // Store the inputs.
-  std::vector<std::vector<double>> layer_inputs;
+  layer_io.front() = input;
 
   // Store the parameters.
   std::vector<std::vector<double>> layer_params;
 
   // Foward pass.
-  for (const LayerPtr& layer : layers_) {
+  for (std::size_t i = 0; i < layers_.size(); ++i) {
+    const LayerPtr& layer = layers_.at(i);
+
     // Get parameters for this layer. TODO: Reduce/avoid copies.
     const int num_params = layer->GetNumParameters();
     const std::vector<double> layer_param(param_begin,
                                           param_begin + num_params);
 
     // Evaluate layer.
-    std::vector<double> layer_output;
-    std::vector<double> layer_activation_gradient;
-    layer->ForwardPass(layer_input, layer_param, &layer_output,
-                       &layer_activation_gradient);
+    layer->ForwardPass(layer_io.at(i), layer_param, &layer_io.at(i + 1),
+                       &layer_activation_gradients.at(i));
 
-    // Store activation gradient. TODO: Reduce/avoid copies.
-    layer_inputs.emplace_back(layer_input);
+    // TODO: Reduce/avoid copies.
     layer_params.emplace_back(layer_param);
-    layer_activation_gradients.emplace_back(layer_activation_gradient);
 
-    // Copy output to next layer's input.
-    layer_input = layer_output;
-
-    // Advance the param index.
+    // Advance the param iterator.
     param_begin += num_params;
   }
 
   // Evaluate loss.
   const Eigen::VectorXd label_vector =
       Eigen::Map<const Eigen::VectorXd>(label.data(), label.size());
-  const Eigen::VectorXd network_output =
-      Eigen::Map<Eigen::VectorXd>(layer_input.data(), layer_input.size());
+
+  // TODO: Can also use layers_.back() if you confirm size is correct.
+  const Eigen::VectorXd network_output = Eigen::Map<Eigen::VectorXd>(
+      layer_io.at(layers_.size()).data(), layer_io.at(layers_.size()).size());
 
   Eigen::VectorXd loss_gradient;
   const Eigen::VectorXd loss =
@@ -123,7 +124,7 @@ double Network::Evaluate(const std::vector<double>& input,
     const LayerPtr& layer = layers_.at(i);
 
     // TODO: Avoid reusing variable names.
-    const std::vector<double>& layer_input = layer_inputs.at(i);
+    const std::vector<double>& layer_input = layer_io.at(i);
     const std::vector<double>& layer_param = layer_params.at(i);
     const std::vector<double>& layer_act_grad =
         layer_activation_gradients.at(i);

--- a/neural_networks/network.cpp
+++ b/neural_networks/network.cpp
@@ -13,36 +13,44 @@ std::vector<double> Network::GetRandomParameters() const {
   return parameters;
 }
 
-std::vector<double> Network::Evaluate(
-    const std::vector<double>& input, const std::vector<double>& label,
-    const std::vector<double>& parameters) const {
+std::vector<double> Network::Evaluate(const std::vector<double>& input,
+                                      const std::vector<double>& label,
+                                      const std::vector<double>& parameters) {
+  // TODO: Pre-allocate these containers and assert that their size is correct.
+  if (layer_io.size() != (layers_.size() + 1)) {
+    std::cerr << "Re-sizing layer IO container" << std::endl;
+    layer_io.resize(layers_.size() + 1);
+  }
+  if (layer_activation_gradients.size() != (layers_.size() + 1)) {
+    std::cerr << "Re-sizing layer activation gradients container" << std::endl;
+    layer_activation_gradients.resize(layers_.size() + 1);
+  }
+
   // Iterator indicating the beginning of the current layer's parameters.
   auto param_begin = parameters.begin();
 
   // Initialize input.
-  std::vector<double> layer_input = input;
+  layer_io.front() = input;
 
   // Foward pass.
-  for (const LayerPtr& layer : layers_) {
+  for (std::size_t i = 0; i < layers_.size(); ++i) {
+    const LayerPtr& layer = layers_.at(i);
+
     // Get parameters for this layer. TODO: Reduce/avoid copies.
     const int num_params = layer->GetNumParameters();
     const std::vector<double> layer_param(param_begin,
                                           param_begin + num_params);
 
     // Evaluate layer.
-    std::vector<double> layer_output;
-    std::vector<double> layer_activation_gradient;
-    layer->ForwardPass(layer_input, layer_param, &layer_output,
-                       &layer_activation_gradient);
-
-    // Copy output to next layer's input.
-    layer_input = layer_output;
+    layer->ForwardPass(layer_io.at(i), layer_param, &layer_io.at(i + 1),
+                       &layer_activation_gradients.at(i));
 
     // Advance the param iterator.
     param_begin += num_params;
   }
 
-  return layer_input;
+  // TODO: Can also use layers_.back() if you confirm size is correct.
+  return layer_io.at(layers_.size());
 }
 
 double Network::Evaluate(const std::vector<double>& input,

--- a/neural_networks/network.hpp
+++ b/neural_networks/network.hpp
@@ -40,6 +40,6 @@ class Network {
 
   // TODO: Compute and pre-allocate the sizes of these containers and their
   // elements, then assert that that size is correct everywhere they are used.
-  std::vector<std::vector<double>> layer_io;
-  std::vector<std::vector<double>> layer_activation_gradients;
+  std::vector<std::vector<double>> layer_io_;
+  std::vector<std::vector<double>> layer_activation_gradients_;
 };

--- a/neural_networks/network.hpp
+++ b/neural_networks/network.hpp
@@ -25,8 +25,7 @@ class Network {
                   const std::vector<double>& label,
                   const std::vector<double>& parameters,
                   std::vector<double>* input_gradient,
-                  std::vector<double>* param_gradient,
-                  NetworkTiming* timing) const;
+                  std::vector<double>* param_gradient, NetworkTiming* timing);
 
   /**
    * Evaluates network using provided input and parameters but does not compute
@@ -38,4 +37,9 @@ class Network {
 
  private:
   std::vector<LayerPtr> layers_;
+
+  // TODO: Compute and pre-allocate the sizes of these containers and their
+  // elements, then assert that that size is correct everywhere they are used.
+  std::vector<std::vector<double>> layer_io;
+  std::vector<std::vector<double>> layer_activation_gradients;
 };

--- a/neural_networks/network.hpp
+++ b/neural_networks/network.hpp
@@ -33,7 +33,7 @@ class Network {
    */
   std::vector<double> Evaluate(const std::vector<double>& input,
                                const std::vector<double>& label,
-                               const std::vector<double>& parameters) const;
+                               const std::vector<double>& parameters);
 
  private:
   std::vector<LayerPtr> layers_;

--- a/neural_networks/network_test.cpp
+++ b/neural_networks/network_test.cpp
@@ -117,7 +117,7 @@ void RunNetworkGradientTest() {
   const int input_size = 10;  // TODO: Enable non-square inputs.
   const int input_channels = 3;
   const int num_categories = 10;
-  const Network network =
+  Network network =
       BuildTestNetwork(input_channels, input_size, input_size, num_categories);
 
   // Get initial set of parameters.
@@ -194,7 +194,7 @@ void RunNetworkLearningTest() {
   const int input_size = 10;  // TODO: Enable non-square inputs.
   const int input_channels = 3;
   const int num_categories = 10;
-  const Network network =
+  Network network =
       BuildTestNetwork(input_channels, input_size, input_size, num_categories);
 
   // Get initial set of parameters.
@@ -256,7 +256,7 @@ void RunNetworkMnistTest() {
   const int input_size = 28;
   const int input_channels = 1;
   const int num_categories = 10;
-  const Network network =
+  Network network =
       BuildTestNetwork(input_channels, input_size, input_size, num_categories);
 
   // Get initial set of parameters.

--- a/neural_networks/network_test.cpp
+++ b/neural_networks/network_test.cpp
@@ -8,7 +8,7 @@
 #include "training.hpp"
 
 static void EvaulateNetworkPerformance(
-    const Network& network, const std::vector<double>& parameters,
+    Network& network, const std::vector<double>& parameters,
     const std::vector<Eigen::VectorXd>& inputs,
     const std::vector<Eigen::VectorXd>& labels) {
   int num_correct = 0;

--- a/neural_networks/nn.hpp
+++ b/neural_networks/nn.hpp
@@ -61,9 +61,10 @@ Eigen::VectorXd Activation(const Eigen::VectorXd& input,
 // identical results to the Eigen-based one above.
 // TODO: After confirming equivalence, make the Eigen-based version an overload
 // that interally calls this implementation.
-std::vector<double> Activation(const std::vector<double>& input,
-                               const ActivationFunction activation_function,
-                               std::vector<double>* activation_gradient);
+void Activation(const std::vector<double>& input,
+                const ActivationFunction activation_function,
+                std::vector<double>* activation,
+                std::vector<double>* activation_gradient);
 
 // TODO: Make Loss output a scalar...not sure why this ever returned a vector.
 Eigen::VectorXd Loss(const Eigen::VectorXd& input, const Eigen::VectorXd& label,


### PR DESCRIPTION
The main change in this PR is to use `Network` member variables to store intermediate data generated during the forward pass. That way, we can allocate it once at the beginning of training and not have to keep re-allocating it at each iteration. The changes in this PR eliminate virtually all of the time spent in the forward pass.

One downside of this approach is that `Evaluate()` can no longer be a `const` function.